### PR TITLE
We use our own base image for the Dockerfile now. This is because Jes…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,6 @@
-FROM rlister/ruby:2.4.0
-MAINTAINER NuRelm <development@nurelm.com>
+FROM nurelmdevelopment/ruby-base-image
 
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive \
-    apt-get install -yq \
-    libssl-dev \
-    locales \
-    git
-
-## set the locale so gems built for utf8
-RUN dpkg-reconfigure locales && \
-    locale-gen C.UTF-8 && \
-    /usr/sbin/update-locale LANG=C.UTF-8
-ENV LC_ALL C.UTF-8
+RUN apt-get install -yq git
 
 ## help docker cache bundle
 WORKDIR /tmp

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  quickbooks-integration:
+    env_file:
+      - ./dev.env
+    ports:
+      - 3001:5000

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,14 +1,8 @@
 version: '3'
 services:
-  web:
-    container_name: quickbooks-integration-container
-    network_mode: bridge
-    build: .
+  quickbooks-integration:
     env_file:
       - ./prod.env
-    restart: always
-    network_mode: bridge
-    volumes:
-      - .:/app
     logging:
       driver: gcplogs
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,5 @@ services:
   quickbooks-integration:
     build: .
     network_mode: bridge
-    container_name: qb-dev-integration-container
-    env_file:
-      - ./dev.env
-    restart: always
-    ports:
-      - 3001:5000
-    network_mode: bridge
     volumes:
       - .:/app

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+docker-compose -f docker-compose.yml \
+               -f docker-compose.dev.yml \
+               ${@:-up -d}

--- a/scripts/run_production.sh
+++ b/scripts/run_production.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+docker-compose -f docker-compose.yml \
+               -f docker-compose.production.yml \
+               ${@:-up -d}


### PR DESCRIPTION
…sie is no longer maintained and apt-get update was failing.

Added scripts to run the integration.

Divided docker-compose info in three files per our inheritance model.