### PR TITLE
Feature/update add update product

### DIFF
--- a/lib/qb_integration/product.rb
+++ b/lib/qb_integration/product.rb
@@ -39,7 +39,8 @@ module QBIntegration
     end
 
     def account_id(account_name)
-      account_service.find_by_name(@config.fetch(account_name)).id
+      name = @product[account_name] || @config.fetch(account_name)
+      account_service.find_by_name(name).id
     end
 
     def attributes(product, is_update = false)

--- a/scripts/run_local_rspec.sh
+++ b/scripts/run_local_rspec.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 docker-compose -f docker-compose.yml \
                -f docker-compose.dev.yml \
-               run --rm -e RAILS_ENV=test quickbooks-integration \
+               run --rm quickbooks-integration \
                sh -c "bundle exec rspec ${@}"

--- a/scripts/run_local_rspec.sh
+++ b/scripts/run_local_rspec.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+docker-compose -f docker-compose.yml \
+               -f docker-compose.dev.yml \
+               run --rm -e RAILS_ENV=test quickbooks-integration \
+               sh -c "bundle exec rspec ${@}"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,9 +6,6 @@ require 'rubygems'
 require 'bundler'
 require "pstore"
 
-require 'dotenv'
-Dotenv.load
-
 require 'spree/testing_support/controllers'
 
 Bundler.require(:default, :test)


### PR DESCRIPTION
The `#account_id` is used by both add and update product and would look for the params in the payload before defaulting to the config.