### PR TITLE
Feature/get vendors

### DIFF
--- a/lib/qb_integration.rb
+++ b/lib/qb_integration.rb
@@ -13,6 +13,8 @@ require 'qb_integration/return_authorization'
 require 'qb_integration/stock'
 require 'qb_integration/purchase_order'
 require 'qb_integration/vendor'
+require 'qb_integration/email'
+require 'qb_integration/phone'
 
 require 'qb_integration/services/base'
 require 'qb_integration/services/account'

--- a/lib/qb_integration.rb
+++ b/lib/qb_integration.rb
@@ -12,6 +12,7 @@ require 'qb_integration/order'
 require 'qb_integration/return_authorization'
 require 'qb_integration/stock'
 require 'qb_integration/purchase_order'
+require 'qb_integration/vendor'
 
 require 'qb_integration/services/base'
 require 'qb_integration/services/account'

--- a/lib/qb_integration/base.rb
+++ b/lib/qb_integration/base.rb
@@ -52,6 +52,10 @@ module QBIntegration
     def purchase_order_service
       @purchase_order_service ||= Service::PurchaseOrder.new(config, payload)
     end
+
+    def vendor_service
+      @vendor_service ||= Service::Vendor.new(config, payload)
+    end
   end
 
   class RecordNotFound < StandardError; end

--- a/lib/qb_integration/base.rb
+++ b/lib/qb_integration/base.rb
@@ -1,5 +1,6 @@
 module QBIntegration
   class Base
+    OBJECT_LIMIT = 50
     include Helper
 
     attr_accessor :payload, :config

--- a/lib/qb_integration/email.rb
+++ b/lib/qb_integration/email.rb
@@ -1,0 +1,9 @@
+module QBIntegration
+  module Email
+    def self.build(email_address)
+      email = Quickbooks::Model::EmailAddress.new
+      email.address = email_address
+      email
+    end
+  end
+end

--- a/lib/qb_integration/phone.rb
+++ b/lib/qb_integration/phone.rb
@@ -1,0 +1,9 @@
+module QBIntegration
+  module Phone
+    def self.build(phonenumber)
+      phone = Quickbooks::Model::TelephoneNumber.new
+      phone.free_form_number = phonenumber
+      phone
+    end
+  end
+end

--- a/lib/qb_integration/services/vendor.rb
+++ b/lib/qb_integration/services/vendor.rb
@@ -37,7 +37,7 @@ module QBIntegration
       def update
         updated_vendor = find_by_name vendor["name"]
         build updated_vendor
-        @quickbooks.create updated_vendor
+        @quickbooks.update updated_vendor
       end
 
       def find_by_name(name)

--- a/lib/qb_integration/services/vendor.rb
+++ b/lib/qb_integration/services/vendor.rb
@@ -1,7 +1,10 @@
 module QBIntegration
   module Service
     class Vendor < Base
-      def initialize(config)
+      attr_reader :vendor
+
+      def initialize(config, payload)
+        @vendor = payload[:vendor]
         super("Vendor", config)
       end
 
@@ -24,12 +27,37 @@ module QBIntegration
         }
       end
 
+      def create
+        new_vendor = create_model
+        build new_vendor
+        @quickbooks.create new_vendor
+      end
+
       def find_by_name(name)
         util = Quickbooks::Util::QueryBuilder.new
         clause = util.clause("CompanyName", "=", name)
         vendor = @quickbooks.query("select * from Vendor where #{clause}").entries.first
         raise "No Vendor '#{name}' defined in service" unless vendor
         vendor
+      end
+
+      private
+
+      def build(new_vendor)
+        new_vendor.title = vendor["sysid"]
+        new_vendor.display_name = vendor["name"]
+        new_vendor.company_name = vendor["name"]
+        new_vendor.primary_phone = Phone.build(vendor["phone"])
+        new_vendor.primary_email_address = Email.build(vendor["email"])
+        new_vendor.billing_address = Address.build({
+          "address1" => vendor["street1"],
+          "address2" => vendor["street2"],
+          "city" => vendor["city"],
+          "country" => vendor["country"],
+          "city" => vendor["city"],
+          "state" => vendor["state"],
+          "zipcode" => vendor["zipcode"],
+        })
       end
     end
   end

--- a/lib/qb_integration/services/vendor.rb
+++ b/lib/qb_integration/services/vendor.rb
@@ -16,7 +16,7 @@ module QBIntegration
         vendor
       end
 
-      def all(date, page = 1, per_page = 25)
+      def all(date, page, per_page)
         total = @quickbooks.all.count
         util = Quickbooks::Util::QueryBuilder.new
         clause = util.clause("Metadata.LastUpdatedTime", ">", date)

--- a/lib/qb_integration/services/vendor.rb
+++ b/lib/qb_integration/services/vendor.rb
@@ -13,10 +13,15 @@ module QBIntegration
         vendor
       end
 
-      def all
+      def all(date, page = 1, per_page = 25)
+        total = @quickbooks.all.count
         util = Quickbooks::Util::QueryBuilder.new
-        vendors = @quickbooks.all
-        vendors
+        clause = util.clause("Metadata.LastUpdatedTime", ">", date)
+        vendors = @quickbooks.query("select * from Vendor where #{clause}", page: page, per_page: per_page)
+        {
+          vendors: vendors,
+          total: total
+        }
       end
 
       def find_by_name(name)

--- a/lib/qb_integration/services/vendor.rb
+++ b/lib/qb_integration/services/vendor.rb
@@ -19,8 +19,9 @@ module QBIntegration
       def all(date, page, per_page)
         total = @quickbooks.all.count
         util = Quickbooks::Util::QueryBuilder.new
-        clause = util.clause("Metadata.LastUpdatedTime", ">", date)
-        vendors = @quickbooks.query("select * from Vendor where #{clause}", page: page, per_page: per_page)
+        clause = util.clause("Where Metadata.LastUpdatedTime", ">", date)
+        order_by = "Order By Metadata.LastUpdatedTime"
+        vendors = @quickbooks.query("select * from Vendor #{clause} #{order_by}", page: page, per_page: per_page)
         {
           vendors: vendors,
           total: total

--- a/lib/qb_integration/services/vendor.rb
+++ b/lib/qb_integration/services/vendor.rb
@@ -13,6 +13,12 @@ module QBIntegration
         vendor
       end
 
+      def all
+        util = Quickbooks::Util::QueryBuilder.new
+        vendors = @quickbooks.all
+        vendors
+      end
+
       def find_by_name(name)
         util = Quickbooks::Util::QueryBuilder.new
         clause = util.clause("CompanyName", "=", name)

--- a/lib/qb_integration/services/vendor.rb
+++ b/lib/qb_integration/services/vendor.rb
@@ -33,6 +33,12 @@ module QBIntegration
         @quickbooks.create new_vendor
       end
 
+      def update
+        updated_vendor = find_by_name vendor["name"]
+        build updated_vendor
+        @quickbooks.create updated_vendor
+      end
+
       def find_by_name(name)
         util = Quickbooks::Util::QueryBuilder.new
         clause = util.clause("CompanyName", "=", name)

--- a/lib/qb_integration/vendor.rb
+++ b/lib/qb_integration/vendor.rb
@@ -26,6 +26,11 @@ module QBIntegration
       [200 , "Vendor with id #{vendor.id} created"]
     end
 
+    def update
+      vendor = vendor_service.update
+      [200 , "Vendor with id #{vendor.id} updated", vendor]
+    end
+
     private
 
     def as_flowlink_hash(vendor)

--- a/lib/qb_integration/vendor.rb
+++ b/lib/qb_integration/vendor.rb
@@ -7,7 +7,7 @@ module QBIntegration
       super
       @vendor = payload[:vendor]
       @config = config
-      @vendor_service = Service::Vendor.new(config)
+      @vendor_service = Service::Vendor.new(config, payload)
     end
 
     def index
@@ -19,6 +19,11 @@ module QBIntegration
       vendors = result[:vendors].map{|vendor| as_flowlink_hash(vendor)}
 
       result[:total] > (per_page * page) ?  [206, vendors] : [200, vendors]
+    end
+
+    def create
+      vendor = vendor_service.create
+      [200 , "Vendor with id #{vendor.id} created"]
     end
 
     private

--- a/lib/qb_integration/vendor.rb
+++ b/lib/qb_integration/vendor.rb
@@ -12,8 +12,8 @@ module QBIntegration
 
     def index
       date = config.fetch("since")
-      page = config.fetch("page")
-      per_page = config.fetch("per_page")
+      page = config.fetch("page", 1)
+      per_page = config.fetch("per_page", OBJECT_LIMIT)
 
       result = vendor_service.all(date, page, per_page)
       vendors = result[:vendors].map{|vendor| as_flowlink_hash(vendor)}

--- a/lib/qb_integration/vendor.rb
+++ b/lib/qb_integration/vendor.rb
@@ -36,13 +36,38 @@ module QBIntegration
     def as_flowlink_hash(vendor)
       {
         id: vendor.id,
+        last_updated_time: vendor.meta_data['last_updated_time'],
         name: vendor.display_name,
-        phone: vendor.primary_phone,
-        email: vendor.primary_email_address,
-        website: vendor.web_site,
-        address: vendor.billing_address,
+        phone: parse_number(vendor),
+        email: parse_email(vendor),
+        website: parse_website(vendor),
+        address: parse_address(vendor),
         currency: vendor.currency_ref['value']
       }
+    end
+
+    def parse_address(vendor)
+      unless vendor.billing_address.nil?
+        {
+          street1: vendor.billing_address.fetch('line1', nil),
+          street2: vendor.billing_address.fetch('line2', nil),
+          city: vendor.billing_address.fetch('city', nil),
+          country: vendor.billing_address.fetch('country', nil),
+          zipcode: vendor.billing_address.fetch('postal_code', nil),
+        }.compact
+      end
+    end
+
+    def parse_number(vendor)
+      vendor.primary_phone.fetch('free_form_number', nil) unless vendor.primary_phone.nil?
+    end
+
+    def parse_email(vendor)
+      vendor.primary_email_address.fetch('address', nil) unless vendor.primary_email_address.nil?
+    end
+
+    def parse_website(vendor)
+      vendor.web_site.fetch('uri', nil) unless vendor.web_site.nil?
     end
   end
 end

--- a/lib/qb_integration/vendor.rb
+++ b/lib/qb_integration/vendor.rb
@@ -1,0 +1,31 @@
+module QBIntegration
+  class Vendor < Base
+    attr_reader :vendor_service
+    attr_accessor :vendor
+
+    def initialize(message = {}, config)
+      super
+      @vendor = payload[:vendor]
+      @vendor_service = Service::Vendor.new(config)
+    end
+
+    def index
+      vendors = vendor_service.all
+      vendors = vendors.map{|vendor| as_flowlink_hash(vendor)}
+      [200, vendors]
+    end
+
+    private 
+    def as_flowlink_hash(vendor)
+      {
+        id: vendor.id,
+        name: vendor.display_name,
+        phone: vendor.primary_phone,
+        email: vendor.primary_email_address,
+        website: vendor.web_site,
+        address: vendor.billing_address,
+        currency: vendor.currency_ref['value']
+      }
+    end
+  end
+end

--- a/quickbooks_endpoint.rb
+++ b/quickbooks_endpoint.rb
@@ -113,7 +113,7 @@ class QuickbooksEndpoint < EndpointBase::Sinatra::Base
     summary = "Retrieved #{vendors.size} vendors"
     vendors.each { |vendor| add_object :vendor, vendor }
     add_parameter "since", @config.fetch("since")
-    add_parameter "page", @config.fetch("page")
+    add_parameter "page", @config.fetch("page", 1)
     result code, summary
   end
 

--- a/quickbooks_endpoint.rb
+++ b/quickbooks_endpoint.rb
@@ -108,6 +108,13 @@ class QuickbooksEndpoint < EndpointBase::Sinatra::Base
     result code, summary
   end
 
+  post '/get_vendors' do
+    code, vendors = QBIntegration::Vendor.new(@payload, @config).index
+    summary = "Retrieved #{vendors.size} vendors"
+    vendors.each { |vendor| add_object :vendor, vendor }
+    result code, summary
+  end
+
   post '/get_inventory' do
     stock = QBIntegration::Stock.new(@payload, @config)
 

--- a/quickbooks_endpoint.rb
+++ b/quickbooks_endpoint.rb
@@ -122,6 +122,12 @@ class QuickbooksEndpoint < EndpointBase::Sinatra::Base
     result code, summary
   end
 
+  post '/update_vendor' do
+    code, summary, vendor = QBIntegration::Vendor.new(@payload, @config).update
+    add_object :vendor, vendor
+    result code, summary
+  end
+
   post '/get_inventory' do
     stock = QBIntegration::Stock.new(@payload, @config)
 

--- a/quickbooks_endpoint.rb
+++ b/quickbooks_endpoint.rb
@@ -112,6 +112,8 @@ class QuickbooksEndpoint < EndpointBase::Sinatra::Base
     code, vendors = QBIntegration::Vendor.new(@payload, @config).index
     summary = "Retrieved #{vendors.size} vendors"
     vendors.each { |vendor| add_object :vendor, vendor }
+    add_parameter "since", @config.fetch("since")
+    add_parameter "page", @config.fetch("page")
     result code, summary
   end
 

--- a/quickbooks_endpoint.rb
+++ b/quickbooks_endpoint.rb
@@ -117,6 +117,11 @@ class QuickbooksEndpoint < EndpointBase::Sinatra::Base
     result code, summary
   end
 
+  post '/add_vendor' do
+    code, summary = QBIntegration::Vendor.new(@payload, @config).create
+    result code, summary
+  end
+
   post '/get_inventory' do
     stock = QBIntegration::Stock.new(@payload, @config)
 


### PR DESCRIPTION
I added pagination on the second commit to be consistent but it might not be needed or it might need to be changed to use the batch queries. When I looked at the documentation at `quickbooks-ruby`, it looked like the default number of items would be 1000 and I'm not sure what the performance would be. Also, I'm getting the total count by running `@quickbooks.all` for the vendor service hoping that it doesn't return all the items and then do the count;  I haven't seen any obvious bottlenecks when I test locally but its something to keep an eye on. Is there a reasonable upper limit of vendors we should support?