### PR TITLE
Feature/fix customer return to fl

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ Copy "sample.env" to ".env" and ".dev.env" and fill out the following variables:
 - quickbooks_shipping_item - Name of the Item in QuickBooks used for adding shipping amount as a line item => **Required**
 - quickbooks_tax_item - Name of the Item in QuickBooks used for adding tax amount as a line item => **Required**
 - quickbooks_payment_method_name - Mapping for payment methods in QuickBooks Online => **Required**
-- quickbooks_web_orders_users - Boolean used to determine if FlowLink should group customers under a general customer called "Web User" instead of creating new customers => **Required**
+- quickbooks_web_orders_users - Boolean used to determine if FlowLink should group customers under a general customer instead of creating new customers => **Required**
+- quickbooks_generic_customer_name - Name of the Customer used when rolling up customers into a general QuickBooks Online customer. Order payload field takes precedence over workflow parameter. Defaults to "Web User" if neither order payload or parameter are set. Unused if quickbooks_web_orders_users is false.
 - quickbooks_create_new_customers - Boolean used to determine if FlowLink should create new customers if the customer on the Order is not found  => **Required**
 - quickbooks_create_new_product - Boolean used to determine if FlowLink should create new items if any line items on the Order are not found  => **Required**
 - quickbooks_track_inventory - Boolean used to determine if the item we're creating is of Type Inventory => **Required if quickbooks_create_new_product is true**
@@ -101,7 +102,8 @@ Copy "sample.env" to ".env" and ".dev.env" and fill out the following variables:
 - quickbooks_shipping_item - Name of the Item in QuickBooks used for adding shipping amount as a line item => **Required**
 - quickbooks_tax_item - Name of the Item in QuickBooks used for adding tax amount as a line item => **Required**
 - quickbooks_payment_method_name - Mapping for payment methods in QuickBooks Online => **Required**
-- quickbooks_web_orders_users - Boolean used to determine if FlowLink should group customers under a general customer called "Web User" instead of creating new customers => **Required**
+- quickbooks_web_orders_users - Boolean used to determine if FlowLink should group customers under a general customer instead of creating new customers => **Required**
+- quickbooks_generic_customer_name - Name of the Customer used when rolling up customers into a general QuickBooks Online customer. Order payload field takes precedence over workflow parameter. Defaults to "Web User" if neither order payload or parameter are set. Unused if quickbooks_web_orders_users is false.
 - quickbooks_create_new_customers - Boolean used to determine if FlowLink should create new customers if the customer on the Order is not found  => **Required**
 - quickbooks_create_new_product - Boolean used to determine if FlowLink should create new items if any line items on the Order are not found  => **Required**
 - quickbooks_track_inventory - Boolean used to determine if the item we're creating is of Type Inventory => **Required if quickbooks_create_new_product is true**
@@ -114,7 +116,8 @@ Copy "sample.env" to ".env" and ".dev.env" and fill out the following variables:
 - quickbooks_discount_item- Name of the Item in QuickBooks used for adding discount amount as a line item => **Required**
 - quickbooks_shipping_item - Name of the Item in QuickBooks used for adding shipping amount as a line item => **Required**
 - quickbooks_tax_item - Name of the Item in QuickBooks used for adding tax amount as a line item => **Required**
-- quickbooks_web_orders_users - Boolean used to determine if FlowLink should group customers under a general customer called "Web User" instead of creating new customers => **Required**
+- quickbooks_web_orders_users - Boolean used to determine if FlowLink should group customers under a general customer instead of creating new customers => **Required**
+- quickbooks_generic_customer_name - Name of the Customer used when rolling up customers into a general QuickBooks Online customer. Invoice payload field takes precedence over workflow parameter. Defaults to "Web User" if neither invoice payload or parameter are set. Unused if quickbooks_web_orders_users is false.
 - quickbooks_create_new_customers - Boolean used to determine if FlowLink should create new customers if the customer on the Invoice is not found  => **Required**
 - quickbooks_create_new_product - Boolean used to determine if FlowLink should create new items if any line items on the Invoice are not found  => **Required**
 - quickbooks_track_inventory - Boolean used to determine if the item we're creating is of Type Inventory => **Required if quickbooks_create_new_product is true**
@@ -129,7 +132,8 @@ Copy "sample.env" to ".env" and ".dev.env" and fill out the following variables:
 - quickbooks_discount_item- Name of the Item in QuickBooks used for adding discount amount as a line item => **Required**
 - quickbooks_shipping_item - Name of the Item in QuickBooks used for adding shipping amount as a line item => **Required**
 - quickbooks_tax_item - Name of the Item in QuickBooks used for adding tax amount as a line item => **Required**
-- quickbooks_web_orders_users - Boolean used to determine if FlowLink should group customers under a general customer called "Web User" instead of creating new customers => **Required**
+- quickbooks_web_orders_users - Boolean used to determine if FlowLink should group customers under a general customer instead of creating new customers => **Required**
+- quickbooks_generic_customer_name - Name of the Customer used when rolling up customers into a general QuickBooks Online customer. Invoice payload field takes precedence over workflow parameter. Defaults to "Web User" if neither invoice payload or parameter are set. Unused if quickbooks_web_orders_users is false.
 - quickbooks_create_new_customers - Boolean used to determine if FlowLink should create new customers if the customer on the Invoice is not found  => **Required**
 - quickbooks_create_new_product - Boolean used to determine if FlowLink should create new items if any line items on the Invoice are not found  => **Required**
 - quickbooks_track_inventory - Boolean used to determine if the item we're creating is of Type Inventory => **Required if quickbooks_create_new_product is true**

--- a/lib/qb_integration/customer.rb
+++ b/lib/qb_integration/customer.rb
@@ -15,12 +15,16 @@ module QBIntegration
 
     def create
       customer = customer_service.create_customer
-      [200 , "Customer with id #{customer.id} created", build_customer(customer)]
+      updated_flowlink_customer = payload[:customer]
+      updated_flowlink_customer[:q_id] = customer.id
+      [200 , "Customer with id #{customer.id} created", updated_flowlink_customer]
     end
 
     def update
       customer = customer_service.update
-      [200 , "Customer with id #{customer.id} updated", build_customer(customer)]
+      updated_flowlink_customer = payload[:customer]
+      updated_flowlink_customer[:q_id] = customer.id
+      [200 , "Customer with id #{customer.id} updated", updated_flowlink_customer]
     end
 
     def build_customer(customer)

--- a/lib/qb_integration/services/customer.rb
+++ b/lib/qb_integration/services/customer.rb
@@ -92,7 +92,7 @@ module QBIntegration
       end
 
       def find_or_create
-        name = use_web_orders? ? "Web Orders" : nil
+        name = use_web_orders? ? quickbooks_generic_customer_name : nil
         unless customer = fetch_by_display_name(name)
           if create_new_customers? || use_web_orders?
             customer = create
@@ -130,7 +130,7 @@ module QBIntegration
       def create
         new_customer = create_model
         if use_web_orders?
-          new_customer.display_name = "Web Orders"
+          new_customer.display_name = quickbooks_generic_customer_name
         else
           new_customer.given_name = order['billing_address'].nil? ? 'NotProvided' :
                                                                     order['billing_address']['firstname']
@@ -186,6 +186,10 @@ module QBIntegration
 
         def find_value(key_name, payload_object, parameters)
           payload_object.fetch(key_name,  parameters.fetch(key_name, "empty")).to_s
+        end
+
+        def quickbooks_generic_customer_name
+          payload['quickbooks_generic_customer_name'] || config['quickbooks_generic_customer_name'] || "Web Orders" 
         end
 
     end

--- a/lib/qb_integration/services/customer.rb
+++ b/lib/qb_integration/services/customer.rb
@@ -189,7 +189,7 @@ module QBIntegration
         end
 
         def quickbooks_generic_customer_name
-          payload['quickbooks_generic_customer_name'] || config['quickbooks_generic_customer_name'] || "Web Orders" 
+          order['quickbooks_generic_customer_name'] || config['quickbooks_generic_customer_name'] || "Web Orders" 
         end
 
     end

--- a/lib/qb_integration/vendor.rb
+++ b/lib/qb_integration/vendor.rb
@@ -22,12 +22,16 @@ module QBIntegration
 
     def create
       vendor = vendor_service.create
-      [200 , "Vendor with id #{vendor.id} created", as_flowlink_hash(vendor)]
+      updated_flowlink_vendor = payload[:vendor]
+      updated_flowlink_vendor[:q_id] = vendor.id
+      [200 , "Vendor with id #{vendor.id} created", updated_flowlink_vendor]
     end
 
     def update
       vendor = vendor_service.update
-      [200 , "Vendor with id #{vendor.id} updated", as_flowlink_hash(vendor)]
+      updated_flowlink_vendor = payload[:vendor]
+      updated_flowlink_vendor[:q_id] = vendor.id
+      [200 , "Vendor with id #{vendor.id} updated", updated_flowlink_vendor]
     end
 
     private
@@ -35,6 +39,7 @@ module QBIntegration
     def as_flowlink_hash(vendor)
       {
         id: vendor.id,
+        q_id: vendor.id,
         last_updated_time: vendor.meta_data['last_updated_time'],
         name: vendor.display_name,
         phone: parse_number(vendor),


### PR DESCRIPTION
- Returns flowlink object BACK to FlowLink after add or update with the q_id set
- Adds "quickbooks_generic_customer_name" option for clients to set a "Generic Customer" in QBO instead of cluttering up the QBO account with lots of B2C customers. Provides backwards compatibility for clients who already use default Generic Customer
- Refactors customer searching into separate method for use elsewhere (soon to come payments PR)