### PR TITLE
Removed the default setting of the name field for firstname/lastname …

### DIFF
--- a/lib/qb_integration/services/customer.rb
+++ b/lib/qb_integration/services/customer.rb
@@ -177,7 +177,6 @@ module QBIntegration
         name = order['billing_address'][name_field] unless order['billing_address'].nil?
         if @customer
           name = @customer['billing_address'][name_field] if @customer['billing_address']
-          name = @customer['name'] if name.nil?
         end
 
         name = name.strip unless name.nil?


### PR DESCRIPTION
Removed the default setting of the name field for firstname/lastname as this can cause a bug where the display name is actually '#{name} #{name}' and looks like 'Marc Salo Marc Salo'. The logic for using the default name field comes AFTER we search for firstname and lastname (in the `display_name` method in lib/qb_integration/services/customer.rb)