### PR TITLE
Error fix

### DIFF
--- a/lib/qb_integration/services/line.rb
+++ b/lib/qb_integration/services/line.rb
@@ -130,8 +130,11 @@ module QBIntegration
           adjustment[:name] = adjustment["name"]
           adjustment[:sku] = sku
 
+          found_item = item_service.find_or_create_by_sku(adjustment, account)
+          raise RecordNotFound.new("Adjustment Item #{adjustment[:name]} with SKU #{adjustment[:sku]} not found in QuickBooks") unless found_item
+
           line.sales_item! do |sales_item|
-            sales_item.item_id = item_service.find_or_create_by_sku(adjustment, account).id
+            sales_item.item_id = found_item.id
             sales_item.quantity = 1
             sales_item.unit_price = adjustment["value"].to_f * multiplier
 


### PR DESCRIPTION
Raise an error when we don't find the adjustment item in QBO rather than seeing 'undefined method [] for nilClass'