### PR TITLE
Use query builder when searching by item name to fix `QueryParserError`

### DIFF
--- a/lib/qb_integration/services/item.rb
+++ b/lib/qb_integration/services/item.rb
@@ -14,12 +14,13 @@ module QBIntegration
         util = Quickbooks::Util::QueryBuilder.new
         clause = util.clause("Name", "=", sku)
         response = quickbooks.query("select #{fields} from Item WHERE #{clause}")
-
         response.entries.first
       end
 
       def find_category_by_name(name, fields = "*")
-        response = quickbooks.query("select #{fields} from Item where Name = '#{name}' and Type='Category'")
+        util = Quickbooks::Util::QueryBuilder.new
+        clause = util.clause("Name", "=", name)
+        response = quickbooks.query("select #{fields} from Item WHERE #{clause} and Type='Category'")
         response.entries.first
       end
 

--- a/lib/qb_integration/services/item.rb
+++ b/lib/qb_integration/services/item.rb
@@ -11,7 +11,10 @@ module QBIntegration
       end
 
       def find_by_name(sku, fields = "*")
-        response = quickbooks.query("select #{fields} from Item where Name = '#{sku}'")
+        util = Quickbooks::Util::QueryBuilder.new
+        clause = util.clause("Name", "=", sku)
+        response = quickbooks.query("select #{fields} from Item WHERE #{clause}")
+
         response.entries.first
       end
 


### PR DESCRIPTION
- Using string interpolation breaks when using single quotes as they're
not escaped as expected.
- Issue Reference: https://github.com/ruckus/quickbooks-ruby/issues/54
- Syntax: https://github.com/ruckus/quickbooks-ruby#query-building--filtering