### PR TITLE
Bug fix for the method `#account_check`

### DIFF
--- a/lib/qb_integration/product.rb
+++ b/lib/qb_integration/product.rb
@@ -155,8 +155,11 @@ module QBIntegration
     end
 
     def account_check(name)
-      @product_payload.fetch(name, false).to_s == '1' ||
-        @config.fetch(name, false).to_s == '1'
+      if @product_payload.fetch(name, false) || @config.fetch(name, false)
+        true
+      else
+        false
+      end
     end
   end
 end


### PR DESCRIPTION
- The previous implementation only worked if the config was set to 1. In
this case, the account name is being passed in