### PR TITLE
Update the credit memo process to find by memo number

### DIFF
--- a/lib/qb_integration/credit_memo.rb
+++ b/lib/qb_integration/credit_memo.rb
@@ -19,7 +19,7 @@ module QBIntegration
     end
 
     def update
-      credit_memo = credit_memo_service.find_by_number(@flowlink_credit_memo[:id])
+      credit_memo = credit_memo_service.find_by_memo_number
 
       if !credit_memo.present? && config[:quickbooks_create_or_update].to_s == "1"
         credit_memo = credit_memo_service.create

--- a/lib/qb_integration/services/credit_memo.rb
+++ b/lib/qb_integration/services/credit_memo.rb
@@ -66,6 +66,11 @@ module QBIntegration
         quickbooks.query(query).entries.first
       end
 
+      def find_by_memo_number
+        query = "SELECT * FROM CreditMemo WHERE DocNumber = '#{memo_number}'"
+        quickbooks.query(query).entries.first
+      end
+
       def update(credit_memo, return_authorization, sales_receipt)
         build_from_return(credit_memo, return_authorization, sales_receipt)
         quickbooks.update(credit_memo)


### PR DESCRIPTION
- The `memo_number` logic is used to determine the document number the
credit memo is created and updated with and this update matches the
querying logic to that